### PR TITLE
Implement Rue (2005) recursive marginal variance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 


### PR DESCRIPTION
Calculates marginal variances using the lower Cholesky factor of the precision matrix. Adds a dependency on Memoize.jl because the algorithm is recursive and will overflow the stack for large precision matrices, not to mention saving the computations. 

Report available at:

https://cds.cern.ch/record/848064/files/cer-002531398.pdf

Addresses #1.