### PR TITLE
Subtype GMRF under AbstractMvNormal

### DIFF
--- a/src/GaussianMarkovRandomFields.jl
+++ b/src/GaussianMarkovRandomFields.jl
@@ -32,7 +32,7 @@ end
 
 struct GMRF{Tv<:AbstractVector{<:Real},
         Tm<:AbstractMatrix{<:Real},
-        Tl<:AbstractMatrix{<:Real}} <: ContinuousMultivariateDistribution
+        Tl<:AbstractMatrix{<:Real}} <: AbstractMvNormal
     μ::Tv
     Q::Tm
     L::Tl


### PR DESCRIPTION
Fixes bijector error when using in a Turing hierarchical model.

@jrfaulkner ran into an error when trying to use Turing to sample a `GMRF` with observation error. An error is thrown about a missing `bijector` for `GMRF`. Subtyping `GMRF <: AbstractMvNormal` rather than our current `GMRF <: ContinuousMultivariateDistribution` solves this. Jim sent me the following example that should work now:

```julia
using GaussianMarkovRandomFields
using Random
using LinearAlgebra
using Turing
using SparseArrays

k = 100 #5_000   # number of measurements in time series
σ = 0.5     # marginal variance
ρ = 0.4     # autocorrelation coefficient # !! Why doesn't 0.8 work? causes sqrt of negative
μ = 5.0     # mean

Q = ar_precision(ρ, k) ./ σ^2

d = GMRF(μ*ones(k), Q)
x = rand(d)  # generates realization of d

@model function AR1y(y)
    n = length(y)
    σ ~ Gamma(2, 3)
    sigy ~ Gamma(2, 3)
    ρ ~ Uniform(0, 0.5)
    μ ~ Normal(0, 10)
    Q = ar_precision(ρ, n) ./ σ^2
    theta ~ GMRF(μ*ones(n), Q)
    y ~ MvNormal(theta, sigy)  # this kills it for some reason
end

sigy = 1.5
yobs1 = x + randn(k)*sigy  

modar1y = AR1y(yobs1)
@time chn_ar1y = sample(modar1y, NUTS(), 1000)